### PR TITLE
Update env.yml

### DIFF
--- a/Hands-on lab/Resources/Azure ML/env.yml
+++ b/Hands-on lab/Resources/Azure ML/env.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
 dependencies:
   - python=3.6.2
+  - gcc=8.2.0
   - scikit-learn
   - pandas
   - pip


### PR DESCRIPTION
Error occurred without gcc, adding resolves issue.

  error: Can not find Rust compiler
  ----------------------------------------
[0m[91m  ERROR: Failed building wheel for cryptography
[0m  Building wheel for fusepy (setup.py): started
  Building wheel for fusepy (setup.py): finished with status 'done'
  Created wheel for fusepy: filename=fusepy-3.0.1-py3-none-any.whl size=10502 sha256=03a3eee76c74999005e662405fd1451c6d96873fc8f4654656b6b9dfdfbfd3b5
  Stored in directory: /root/.cache/pip/wheels/21/5c/83/1dd7e8a232d12227e5410120f4374b33adeb4037473105b079
  Building wheel for liac-arff (setup.py): started
  Building wheel for liac-arff (setup.py): finished with status 'done'
  Created wheel for liac-arff: filename=liac_arff-2.5.0-py3-none-any.whl size=11731 sha256=7dc17fbc3c96d3f60f3ebb01e221838b04adeb8de362ccf0b59435224e3f64cb
  Stored in directory: /root/.cache/pip/wheels/53/ba/da/8562a6a6dbb428fd1ecc21053106df3948645cd991958f669b
Successfully built json-logging-py fusepy liac-arff
Failed to build cryptography
[91mERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
[0m[91m